### PR TITLE
Bug 1087161 - Use gcc-4.9 toolchain to build Gecko (lollipop) r=gerar…

### DIFF
--- a/aosp_shamu.mk
+++ b/aosp_shamu.mk
@@ -40,6 +40,8 @@ TARGET_DEVICE_BLOBS := vendor/moto/shamu/device-partial.mk \
                        vendor/broadcom/shamu/device-partial.mk \
                        vendor/qcom/shamu/device-partial.mk
 
+# Set Gecko toolchain
+GECKO_TOOLS_PREFIX = prebuilts/gcc/$(HOST_PREBUILT_TAG)/arm/arm-linux-androideabi-4.9/bin/arm-linux-androideabi-
 
 PRODUCT_NAME := aosp_shamu
 


### PR DESCRIPTION
…d-majax
